### PR TITLE
Add devcontainer command history syncing stubs

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,6 +4,8 @@
 ARG VARIANT="ubuntu-21.04"
 FROM mcr.microsoft.com/vscode/devcontainers/cpp:0-${VARIANT}
 
+ARG USERNAME=vscode
+
 #
 # Install bazelisk
 #
@@ -25,3 +27,10 @@ RUN if [[ `dpkg --print-architecture` == "arm64" ]]; then \
         wget https://github.com/bazelbuild/buildtools/releases/latest/download/buildifier-linux-amd64 -O /usr/local/bin/buildifier \
         && chmod +x /usr/local/bin/buildifier; \
     fi
+
+#
+# Set up command history volume
+# See https://code.visualstudio.com/remote/advancedcontainers/persist-bash-history
+#
+RUN mkdir /commandhistory \
+    && chown -R $USERNAME /commandhistory

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,5 +26,9 @@
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "gcc -v",
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "vscode"
+	"remoteUser": "vscode",
+	// For sharing shell history out of the container.
+	"mounts": [
+		"source=bazel-cpp20-commandhistory,target=/commandhistory,type=volume"
+	]
 }

--- a/README.md
+++ b/README.md
@@ -48,3 +48,34 @@ To run the fuzzer:
 bazel build --config=asan-fuzzer //sample:sample_fuzzer
 bazel-bin/sample/sample_fuzzer
 ```
+
+## Devcontainer
+
+To use the devcontainer, install the VSCode [Remote - Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension.
+
+### Command History Syncing
+
+Command history syncing hooks, based on the [Advanced Containers: Persist bash history](https://code.visualstudio.com/remote/advancedcontainers/persist-bash-history) docs, are included.  Final registration is required to enable them, so it is recommended to use Dotfiles and add the following registration:
+
+#### Zsh Registration
+```
+# See https://code.visualstudio.com/remote/advancedcontainers/persist-bash-history
+if [ -d /commandhistory ]; then
+  touch /commandhistory/.zsh_history
+  export HISTFILE="/commandhistory/.zsh_history"
+else
+  echo "Warning: Could not enable history sharing, there is no /commandhistory directory."
+fi
+```
+
+#### Bash Registration
+```
+# See https://code.visualstudio.com/remote/advancedcontainers/persist-bash-history
+if [ -d /commandhistory ]; then
+  touch /commandhistory/.bash_history
+  export PROMPT_COMMAND='history -a'
+  export HISTFILE="/commandhistory/.bash_history"
+else
+  echo "Warning: Could not enable history sharing, there is no /commandhistory directory."
+fi
+```


### PR DESCRIPTION
This enables sharing command history between rebuilds of the container, based on these docs: https://code.visualstudio.com/remote/advancedcontainers/persist-bash-history

Note that to enable it, additional registration is required in either .zshrc or .bashrc. This is documented in the README.