### PR TITLE
Code coverage support

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -15,6 +15,15 @@ build --config=c++20 --config=with-absl
 # Fixes symbols when debugging on mac.
 build:macos --features=oso_prefix_is_pwd
 
+# Coverage builds
+coverage --config=coverage
+build:coverage --action_env=BAZEL_USE_LLVM_NATIVE_COVERAGE=1
+build:coverage --action_env=GCOV=llvm-profdata
+build:coverage --action_env=BAZEL_LLVM_COV=llvm-cov
+build:coverage --experimental_generate_llvm_lcov
+build:coverage --collect_code_coverage
+build:coverage --combined_report=lcov
+
 # Basic ASAN/UBSAN that works for gcc
 build:asan --linkopt -ldl
 build:asan --copt -fsanitize=address,undefined

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -29,6 +29,12 @@ RUN if [[ `dpkg --print-architecture` == "arm64" ]]; then \
     fi
 
 #
+# Install coverage dependencies: java and lcov
+#
+RUN export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends openjdk-11-jdk lcov
+
+#
 # Set up command history volume
 # See https://code.visualstudio.com/remote/advancedcontainers/persist-bash-history
 #

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,9 +9,7 @@ on:
   pull_request:
     branches: [ main ]
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
     # 20.04 is the latest version available as of 2022-05-01, see
@@ -22,6 +20,11 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
+
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
 
     - name: Install bazelisk
       run: |
@@ -36,3 +39,23 @@ jobs:
     - name: Test
       run: |
         "${GITHUB_WORKSPACE}/bin/bazel" test //...
+
+    - name: Coverage
+      run: |
+        "${GITHUB_WORKSPACE}/bin/bazel" coverage \
+          --local_test_jobs=1 \
+          --nocache_test_results \
+          //...
+
+    # Optional if upload_to_codecov is enabled (disabled unless CODECOV_TOKEN secret has been set)
+    - name: Upload Coverage
+      env: 
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      if: env.CODECOV_TOKEN != ''
+      uses: codecov/codecov-action@v2
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./bazel-out/_coverage/_coverage_report.dat
+        flags: unittests
+        fail_ci_if_error: true
+        verbose: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-bazel-*
+/bazel-*
+/coverage-report

--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ These dependencies are automatically installed in the devcontainer.  Outside of 
 sudo apt-get openjdk-11-jdk lcov
 ```
 
+### Integration with Codecov.io
+
+To enable uploading Code Coverage to https://codecov.io, find your repositories upload token, see the instructions in the Codecov FAQ: [Where is the repository upload token found?](https://docs.codecov.com/docs/frequently-asked-questions#where-is-the-repository-upload-token-found).
+
+Then set it as a GitHub Actions Secret using the GitHub [Creating encrypted secrets for a repository](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository) instructions.
+
 ## Devcontainer
 
 To use the devcontainer, install the VSCode [Remote - Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ To enable uploading Code Coverage to https://codecov.io, find your repositories 
 
 Then set it as a GitHub Actions Secret using the GitHub [Creating encrypted secrets for a repository](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository) instructions.
 
+See this template's code coverage report for an example: https://codecov.io/gh/jwmcglynn/bazel-cpp20
+
 ## Devcontainer
 
 To use the devcontainer, install the VSCode [Remote - Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,21 @@ bazel build --config=asan-fuzzer //sample:sample_fuzzer
 bazel-bin/sample/sample_fuzzer
 ```
 
+## Code Coverage
+
+Coverage support is included based on the built-in `bazel coverage` sub-command, and a helper is included to wrap functionality and generate a coverage report.
+
+To run it, first ensure that java and lcov are installed, and then run:
+
+```
+build/coverage.sh
+```
+
+These dependencies are automatically installed in the devcontainer.  Outside of the devcontainer, this is the Ubuntu install command:
+```
+sudo apt-get openjdk-11-jdk lcov
+```
+
 ## Devcontainer
 
 To use the devcontainer, install the VSCode [Remote - Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension.

--- a/build/coverage.sh
+++ b/build/coverage.sh
@@ -1,0 +1,35 @@
+#!/bin/bash -e
+# Change current directory to the bazel workspace root.
+cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/.."
+
+if [ ! `which java` ]; then
+  echo "Error: Java is not installed."
+  exit 1
+fi
+
+if [ ! `which genhtml` ]; then
+  echo "Error: Could not find genhtml, is lcov installed?"
+  exit 1
+fi
+
+JAVA_HOME=$(dirname $(dirname $(which java)))
+
+bazel coverage -s \
+    --local_test_jobs=1 \
+    --nocache_test_results \
+    //...
+
+genhtml bazel-out/_coverage/_coverage_report.dat \
+    --highlight \
+    --legend \
+    --output-directory coverage-report
+
+echo ""
+echo "Report saved to coverage-report/index.html"
+
+if [ -n `which python3` ]; then
+  echo "Starting webserver, Ctrl-C to exit..."
+  python3 -m http.server --directory coverage-report
+else
+  echo "Not starting webserver, python3 is not installed."
+fi


### PR DESCRIPTION
Add code coverage support using `bazel coverage`, with a simple wrapper script to generate a html report.

Build coverage in CI, and optionally upload to Codecov.io if a `CODECOV_TOKEN` is configured.

See the instructions in the README for how to use the `build/coverage.sh` script and configure the optional Codecov.io integration.

This closes #4.